### PR TITLE
Add mock CrossSpaceCall and test

### DIFF
--- a/contracts/debug/CrossSpaceCallDebug.sol
+++ b/contracts/debug/CrossSpaceCallDebug.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "../internal/CrossSpaceCall.sol";
+import "../XCFX.sol";
+
+contract CrossSpaceCallDebug{
+    MockCrossSpaceCall crossSpaceCall;
+    XCFX tokenContract;
+
+    constructor(address csc_addr){
+        crossSpaceCall = MockCrossSpaceCall(csc_addr);
+        XCFX c = new XCFX();
+        tokenContract = c;
+        c.addMinter(address(this));
+    }
+
+    function setToken(address target, uint value) public {
+        if (tokenContract.balanceOf(target) > value) {
+            tokenContract.burnTokens(target, tokenContract.balanceOf(target) - value);
+        }
+        else {
+            tokenContract.addTokens(target, value - tokenContract.balanceOf(target));
+        }
+    }
+
+    function testCallEVM() public returns (bytes memory output) {
+        address mappedAddress = address(crossSpaceCall.getMockMapped(address(this)));
+        this.setToken(mappedAddress, 1000);
+        require(tokenContract.balanceOf(mappedAddress) == 1000, "set self token failed");
+        // transfer back
+        output = crossSpaceCall.callEVM(bytes20(address(tokenContract)), abi.encodeWithSignature("transfer(address,uint256)", address(this), 500));
+        require(tokenContract.balanceOf(mappedAddress) == 500, string(output));
+        // return output;
+    }
+}
+

--- a/contracts/internal/CrossSpaceCall.sol
+++ b/contracts/internal/CrossSpaceCall.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 // import "../ICrossSpaceCall.sol";
-import "./MockMappingAddress.sol";
+import "./MockMappedAddress.sol";
 
 contract MockCrossSpaceCall {
 

--- a/contracts/internal/CrossSpaceCall.sol
+++ b/contracts/internal/CrossSpaceCall.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// import "../ICrossSpaceCall.sol";
+import "./MockMappingAddress.sol";
+
+contract MockCrossSpaceCall {
+
+    mapping(address=>bytes20) core2e;
+    // mapping(bytes20=>address) e2core;
+
+    function transferEVM(bytes20 to) external payable returns (bytes memory output) {
+        address payable mappedAddress = payable(address(core2e[msg.sender]));
+        require(mappedAddress != address(0), "mock mapped address is not set");
+        return MockMappedAddress(mappedAddress).transferEVM{value: msg.value}(to);
+    }
+
+    function callEVM(bytes20 to, bytes calldata data) external payable returns (bytes memory output) {
+        address payable mappedAddress = payable(address(core2e[msg.sender]));
+        require(mappedAddress != address(0), "mock mapped address is not set");
+        return MockMappedAddress(mappedAddress).callEVM{value: msg.value}(to, data);
+    }
+
+    function staticCallEVM(bytes20 to, bytes calldata data) external payable returns (bytes memory output) {
+        address payable mappedAddress = payable(address(core2e[msg.sender]));
+        require(mappedAddress != address(0), "mock mapped address is not set");
+        return MockMappedAddress(mappedAddress).staticCallEVM(to, data);
+    }
+
+    function withdrawFromMapped(uint256 value) external {
+        address payable mappedAddress = payable(address(core2e[msg.sender]));
+        require(mappedAddress != address(0), "mock mapped address is not set");
+        MockMappedAddress(mappedAddress).withdraw(value);
+    }
+
+    function mappedBalance(address addr) external view returns (uint256){
+        // require(core2e[addr] != address(0))
+        require(address(core2e[addr]) != address(0), "mocked map address is not set");
+        return address(core2e[addr]).balance;
+    }
+
+    // function mappedNonce(address addr) external view returns (uint256);
+
+    // interface for mock
+    function setMockMapped(address coreAddress, bytes20 eAddress) public {
+        core2e[coreAddress] = eAddress;
+        // e2core[eAddress] = coreAddress;
+    }
+
+    // interface for mock
+    function getMockMapped(address coreAddress) external view returns (bytes20) {
+        require(core2e[coreAddress] != 0, "mock mapped address is not set");
+        return core2e[coreAddress];
+    }
+
+    // function getMockReverseMapped(bytes20 eAddress) external view returns (address) {
+    //     return e2core[eAddress];
+    // }
+}

--- a/contracts/internal/MockMappedAddress.sol
+++ b/contracts/internal/MockMappedAddress.sol
@@ -1,15 +1,13 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "./CrossSpaceCall.sol";
-
 contract MockMappedAddress {
 
     address coreAddress;
 
-    constructor(address _address) {
+    constructor(address _coreAddress) {
         // set origin
-        coreAddress = _address;
+        coreAddress = _coreAddress;
     }
 
     function transferEVM(bytes20 to) external payable returns (bytes memory output) {
@@ -36,7 +34,6 @@ contract MockMappedAddress {
         // so we do not add permission check here
         bool success;
         require(address(this).balance >= value, "No enough balance in mapped address");
-        // address ori = MockCrossSpaceCall(msg.sender).getMockReverseMapped(bytes20(address(this)));
         (success, ) = coreAddress.call{value: value}("");
         require(success, "CFX Transfer Failed");
     }

--- a/contracts/internal/MockMappingAddress.sol
+++ b/contracts/internal/MockMappingAddress.sol
@@ -1,0 +1,44 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "./CrossSpaceCall.sol";
+
+contract MockMappedAddress {
+
+    address coreAddress;
+
+    constructor(address _address) {
+        // set origin
+        coreAddress = _address;
+    }
+
+    function transferEVM(bytes20 to) external payable returns (bytes memory output) {
+        bool success;
+        (success, output) = address(to).call{value: msg.value}("");
+        require(success, "CFX Transfer Failed");
+    }
+
+    function callEVM(bytes20 to, bytes calldata data) external payable returns (bytes memory output) {
+        bool success;
+        (success, output) = address(to).call{value: msg.value}(data);
+        require(success, string(output));
+    }
+
+    function staticCallEVM(bytes20 to, bytes calldata data) external payable returns (bytes memory output) {
+        bool success;
+        (success, output) = address(to).staticcall(data);
+        require(success, string(output));
+    }
+
+    function withdraw(uint value) external {
+        // This is a function used to mock the execution of withdrawFromMapped
+        // and should not be used in production environment
+        // so we do not add permission check here
+        bool success;
+        require(address(this).balance >= value, "No enough balance in mapped address");
+        // address ori = MockCrossSpaceCall(msg.sender).getMockReverseMapped(bytes20(address(this)));
+        (success, ) = coreAddress.call{value: value}("");
+        require(success, "CFX Transfer Failed");
+    }
+    receive() external payable {}
+}

--- a/test/CrossSpaceCall.test.js
+++ b/test/CrossSpaceCall.test.js
@@ -1,0 +1,49 @@
+const hre = require("hardhat");
+const { expect } = require("chai");
+const { ethers } = hre;
+const { parseEther } = require("ethers/lib/utils");
+
+describe("MockCrossSpaceCall Tests", async function() {
+    it("should withdraw mapped balance", async () => {
+        const [owner, ] = await ethers.getSigners();
+
+        const MockMappedAddress = await ethers.getContractFactory("MockMappedAddress")
+        const MappedAddress = await MockMappedAddress.deploy(owner.address)
+
+        const MockCrossSpaceCall = await ethers.getContractFactory("MockCrossSpaceCall")
+        const CrossSpaceCall = await MockCrossSpaceCall.deploy()
+
+        await MappedAddress.deployed()
+        await CrossSpaceCall.deployed()
+
+
+        // Note: This is an extra step to create mapping between account and mapping address
+        await CrossSpaceCall.setMockMapped(owner.address, MappedAddress.address)
+
+        await CrossSpaceCall.transferEVM(MappedAddress.address, {value: 1000})
+
+        await expect( await ethers.provider.getBalance(MappedAddress.address) ).to.be.equal(1000)
+
+        await CrossSpaceCall.withdrawFromMapped(1000)
+
+        await expect( await ethers.provider.getBalance(MappedAddress.address) ).to.be.equal(0)
+    })
+
+    it("should call evm success", async () => {
+        const [owner, ] = await ethers.getSigners();
+
+        const MockCrossSpaceCall = await ethers.getContractFactory("MockCrossSpaceCall")
+        const CrossSpaceCall = await MockCrossSpaceCall.deploy()
+        await CrossSpaceCall.deployed()
+
+        const CrossSpaceCallDebug = await (await ethers.getContractFactory("CrossSpaceCallDebug")).deploy(CrossSpaceCall.address)
+        await CrossSpaceCallDebug.deployed()
+
+        // set a mapping address for CrossSpaceCallDebug
+        const MockMappedAddress = await ethers.getContractFactory("MockMappedAddress")
+        const MappedAddress = await MockMappedAddress.deploy(CrossSpaceCallDebug.address)
+        await CrossSpaceCall.setMockMapped(CrossSpaceCallDebug.address, MappedAddress.address)
+
+        await CrossSpaceCallDebug.testCallEVM()
+    })
+})


### PR DESCRIPTION
Here is a PR to mock `CrossSpaceCall`.

* `transferEVM`, `callEVM`, `staticCallEVM`, `withdrawFromMapped` are added
*  `transferEVM`, `callEVM`, `withdrawFromMapped` are tested
*  use cases are in `test/CrossSpaceCall.test.js`

Limitations:

If one account is to use `CrossSpaceCall`, a `MockMappedAddress` contract should be deployed and use the account address as param. Besides, 
You can refer to `test/CrossSpaceCall.test.js` for the usage example

``` js
const MockMappedAddress = await ethers.getContractFactory("MockMappedAddress")
const MappedAddress = await MockMappedAddress.deploy(owner.address)
await CrossSpaceCall.setMockMapped(owner.address, MappedAddress.address)
```
